### PR TITLE
firebaseのバージョンを変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@zeit/next-mdx": "^1.2.0",
     "dotenv": "^8.2.0",
     "dotenv-webpack": "^1.8.0",
-    "firebase": "^8.4.2",
+    "firebase": "^7.15.1",
     "gray-matter": "^4.0.2",
     "jquery": "^3.5.1",
     "next": "^9.4.4",


### PR DESCRIPTION
最新のmasterブランチで`npm install`した際にfirebaseのバージョン取得が以下のエラーでできなかったため修正しました。

```
➜  ceaper git:(master) npm install
npm ERR! code ETARGET
npm ERR! notarget No matching version found for firebase@^8.4.2.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm ERR! notarget
npm ERR! notarget It was specified as a dependency of 'ceaper'
npm ERR! notarget
```